### PR TITLE
Add the file:// prefix to the report path to enable the link

### DIFF
--- a/src/main/java/org/jboss/maven/plugins/qstools/QSCheckerReporter.java
+++ b/src/main/java/org/jboss/maven/plugins/qstools/QSCheckerReporter.java
@@ -215,7 +215,11 @@ public class QSCheckerReporter extends AbstractMavenReport {
             startReport(checkers, locale);
             doFileSummary(globalFilesViolations);
             doFileReports(globalFilesViolations);
-            getLog().info("Your report is ready at " + mavenProject.getModel().getReporting().getOutputDirectory() + File.separator + getOutputName() + ".html");
+            // Display both the file name and a link for browser access 
+            String reportName = mavenProject.getModel().getReporting().getOutputDirectory() + File.separator + getOutputName() + ".html";
+            getLog().info("Your report is ready at " + reportName + System.getProperty("line.separator") + 
+                "       You can access the report using Chrome or Firefox at the following URL: " + 
+                System.getProperty("line.separator") + "            file://" + reportName);
         } catch (Exception e) {
             throw new MavenReportException(e.getMessage(), e);
         }


### PR DESCRIPTION
In addition to providing the report location: /home/sgilda/GitRepos/quickstart-jdf/ejb-timer/target/site/qschecker.html
Add a link to the file for browser access: file:///home/sgilda/GitRepos/quickstart-jdf/ejb-timer/target/site/qschecker.html

This is an example of the output:

[INFO] Your report is ready at /home/sgilda/GitRepos/quickstart-jdf/ejb-timer/target/site/qschecker.html
       You can access the report using Chrome or Firefox at the following URL: 
            file:///home/sgilda/GitRepos/quickstart-jdf/ejb-timer/target/site/qschecker.html
