### PR TITLE
Make QStools ignore all files in hidden directory hierarchy

### DIFF
--- a/config/qstools_config.yaml
+++ b/config/qstools_config.yaml
@@ -80,7 +80,7 @@ rules:
            #target
            - "**/target/**"
            #hidden files and directories
-           - "**/.*/*.*"
+           - "**/.*/**"
            - ".*"
            #known libraries
            - "**/jquery*"


### PR DESCRIPTION
Correction for https://issues.jboss.org/browse/JDF-437
