### PR TITLE
Fixed bug where maven.compiler properties were not set

### DIFF
--- a/src/main/java/org/jboss/maven/plugins/qstools/fixers/MavenCompilerFixer.java
+++ b/src/main/java/org/jboss/maven/plugins/qstools/fixers/MavenCompilerFixer.java
@@ -47,8 +47,8 @@ public class MavenCompilerFixer extends AbstractBaseFixerAdapter {
         String compilerSource = getConfigurationProvider().getQuickstartsRules(project.getGroupId()).getExpectedCompilerSource();
 
         ensurePropertiesElementExists(doc);
-        ensurePropertySet(project, doc, "maven.compiler.target", compilerSource);
-        ensurePropertySet(project, doc, "maven.compiler.source", compilerSource);
+        ensurePropertySet(doc, "maven.compiler.target", compilerSource);
+        ensurePropertySet(doc, "maven.compiler.source", compilerSource);
 
         Node pluginsNode = (Node) getxPath().evaluate("/project/build/plugins", doc, XPathConstants.NODE);
         Node compilerNode = (Node) getxPath().evaluate("/project/build/plugins/plugin[artifactId='maven-compiler-plugin']", doc, XPathConstants.NODE);
@@ -83,19 +83,18 @@ public class MavenCompilerFixer extends AbstractBaseFixerAdapter {
         }
     }
 
-    private void ensurePropertySet(MavenProject project, Document doc, String key, String value) throws Exception {
+    private void ensurePropertySet(Document doc, String key, String value) throws Exception {
 
         Element propertiesElement = (Element) getxPath().evaluate("/project/properties", doc, XPathConstants.NODE);
-        String target = project.getProperties().getProperty(key);
+        Element property = (Element) getxPath().evaluate("/project/properties/"+key, doc, XPathConstants.NODE);
 
-        if (target == null) {
+        if (property == null) {
             Element targetElement = doc.createElement(key);
             targetElement.setTextContent(value);
             propertiesElement.appendChild(doc.createTextNode("    "));
             propertiesElement.appendChild(targetElement);
             propertiesElement.appendChild(doc.createTextNode("\n    "));
-        } else if (!target.equals(value)) {
-            Node property = (Node) getxPath().evaluate("/project/properties/" + key, doc, XPathConstants.NODE);
+        } else if (!property.getTextContent().equals(value)) {
             property.setTextContent(value);
         }
     }


### PR DESCRIPTION
This fixes a bug where 'project.getProperties().getProperty(key);' was returning a value of '1.6' despite the property not being set in the pom.xml. I suspect maven was defaulting to this somehow.

I've fixed the fixer to look for the actual property.
